### PR TITLE
Replace "namelist" with "config", and fix plotting and averaging bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Along with these python requirements, the `ncrcat` NetCDF Operator (NCO) is also
 
 ## Running CAM diagnostics
 
-To run an example of the CAM diagnostics, simply download this repo, setup your computing environment as described in the "Required software environment" section above, modify the `example_namelist.yaml` file (or create one of your own) to point to the relevant diretories and run:
+To run an example of the CAM diagnostics, simply download this repo, setup your computing environment as described in the "Required software environment" section above, modify the `config_example.yaml` file (or create one of your own) to point to the relevant diretories and run:
 
-`./run_diag --namelist example_namelist.yaml`
+`./run_diag --config_file config_example.yaml`
 
 This should generate a collection of time series files, climatology (climo) files, re-gridded climo files, and example CAM diagnostic figures, all in their respective directories.
 

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,7 +1,7 @@
 #-------------------------------
-#example_namelist.yaml
+#config_example.yaml
 
-#This is an example CAM diagnostics namelist file,
+#This is an example CAM diagnostics configuration file,
 #which includes examples of each type of allowed input,
 #along with a short description of what the input does.
 

--- a/run_diag
+++ b/run_diag
@@ -6,7 +6,7 @@ script: run_diag
 goal:  To allow a user to easily run the CAM diagnostics package from
        the command line.
 
-Inputs:  The CAM diagnostics namelist file (in YAML format).  If the file is
+Inputs:  The CAM diagnostics config file (in YAML format).  If the file is
          located in a different directory then the system path must also be
          included.
 
@@ -73,8 +73,8 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description='Command-line wrapper to run the CAM diagnostics package.')
 
     #Add input arguments to be parsed:
-    parser.add_argument('--namelist', metavar='<DIAG_YAML_FILE>', action='store', type=str,
-                        help="namelist YAML file used to configure CAM diagnostics (see example_namelist.yaml)")
+    parser.add_argument('--config_file', metavar='<DIAG_YAML_FILE>', action='store', type=str,
+                        help="YAML file used to configure CAM diagnostics (see config_example.yaml)")
 
     #Parse Argument inputs
     args = parser.parse_args()
@@ -109,15 +109,15 @@ if __name__ == "__main__":
 
     args = parse_arguments()
 
-    #Extract YAML namelist file name/path:
-    namelist_yaml = args.namelist
+    #Extract YAML config file name/path:
+    config_yaml = args.config_file
 
     #+++++++++++++++++++++++++++++++++
     #Call main CAM diagnostics methods
     #+++++++++++++++++++++++++++++++++
 
     #Initalize CAM diagnostics object:
-    diag = CamDiag(namelist_yaml)
+    diag = CamDiag(config_yaml)
 
     #Create CAM time series:
     diag.create_time_series()
@@ -128,12 +128,12 @@ if __name__ == "__main__":
 
     #Create CAM climatology (climo) files.
     #This call uses the "time_averaging_script" specified
-    #in the namelist file:
+    #in the config file:
     diag.create_climo()
 
     #Create CAM baseline climatology files (if needed).
     #This call uses the "time_averaging_script" specified
-    #in the namelist file:
+    #in the config file:
     if not diag.compare_obs:
         diag.create_climo(baseline=True)
 

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -58,7 +58,7 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list):
             time = cam_ts_data['time']
             time = xr.DataArray(cam_ts_data['time_bnds'].mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
             cam_ts_data['time'] = time
-            cam_ts_data.assign_coords({'time':time})
+            cam_ts_data.assign_coords(time=time)
             cam_ts_data = xr.decode_cf(cam_ts_data)
 
         #Group time series values by month, and average those months together:

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -53,10 +53,13 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list):
         else:
             cam_ts_data = xr.open_mfdataset(ts_files, decode_times=True, combine='by_coords')
 
-        #Average time dimension over time bands, if the bands exist:
+        #Average time dimension over time bounds, if bounds exist:
         if 'time_bnds' in cam_ts_data:
-             cam_ts_data['time'].values = cam_ts_data['time_bnds'].mean(dim='nbnd')
-             cam_ts_data = xr.decode_cf(cam_ts_data)
+            time = cam_ts_data['time']
+            time = xr.DataArray(cam_ts_data['time_bnds'].mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
+            cam_ts_data['time'] = time
+            cam_ts_data.assign_coords({'time':time})
+            cam_ts_data = xr.decode_cf(cam_ts_data)
 
         #Group time series values by month, and average those months together:
         cam_climo_data = cam_ts_data.groupby('time.month').mean(dim='time')

--- a/scripts/plotting/plot_example.py
+++ b/scripts/plotting/plot_example.py
@@ -220,7 +220,7 @@ def plot_map_and_save(wks, mdlfld, obsfld, diffld, **kwargs):
     minval = np.min([np.min(mdlfld), np.min(obsfld)])
     maxval = np.max([np.max(mdlfld), np.max(obsfld)])
     normfunc, mplv = use_this_norm()
-    if np.sign(minval) != np.sign(maxval) and mplv > 2:
+    if ((minval < 0) and (0 < maxval)) and mplv > 2:
         norm1 = normfunc(vmin=minval, vmax=maxval, vcenter=0.0)
         cmap1 = 'coolwarm'
     else:


### PR DESCRIPTION
This PR is designed to replace the "namelist" nomenclature with "config" or "configuration", which can help avoid confusion with the Fortran "namelist" system.  This PR also fixes several bugs found by @brianpm while attempting to run a model versus model (baseline) comparison.

Fixes #8 
Fixes #9 
Fixes #10 
Fixes #11 

