### PR TITLE
Add whitespace to config files

### DIFF
--- a/config_cam_baseline.yaml
+++ b/config_cam_baseline.yaml
@@ -62,10 +62,10 @@ diag_cam_climo:
   cam_hist_loc: /location/where/you/stored/model/outputs
 
   #model year when climatology should start:
-  start_year: 1986
+  start_year: 1850
 
   #model year when diagnostics should end:
-  end_year: 2005
+  end_year: 2100
 
   #Save interim time series files?
   #WARNING:  This can take up a significant amount of space:
@@ -95,10 +95,10 @@ diag_cam_baseline_climo:
   cam_hist_loc: /location/of/second/cam/run/output/or/baseline/data
 
   #model year when climatology should start:
-  start_year: 1986
+  start_year: 1850
 
   #model year when diagnostics should end:
-  end_year: 2005
+  end_year: 2100
 
   #Save interim time series files for baseline run?
   #WARNING:  This can take up a significant amount of space:

--- a/config_cam_baseline.yaml
+++ b/config_cam_baseline.yaml
@@ -15,74 +15,99 @@
 
 #This first set of variables specify basic info required by all diagnostic runs:
 diag_basic_info:
+
   #Is this a model vs observations comparison?
   #If "false", then a model-model comparison is assumed:
   compare_obs: false
+
   #Location of observational climatologies (only matters if "compare_obs" is true):
   obs_climo_loc: /glade/work/brianpm/observations/climo_files
+
   #Name of CAM case (or CAM run name):
-  cam_case_name: new_best.came-run
+  cam_case_name: f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001
+
   #Location of CAM climatologies:
-  cam_climo_loc: /some/where/you/want/to/have/it
+  cam_climo_loc: /glade/scratch/nusbaume/cam_diag_climo_files/f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001
+
   #Name of CAM baseline case (only matters if "compare_obs" is false):
-  cam_baseline_case_name: best.cam_run-ever
+  cam_baseline_case_name: f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001
+
   #Location of baseline CAM cliimatologies (only matters if "compare_obs" is false):
-  cam_baseline_climo_loc: /some/where/else/you/want/to/have/it
+  cam_baseline_climo_loc: /glade/scratch/nusbaume/cam_diag_climo_files/f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001
+
   #Location where re-gridded CAM climatology files are stored:
-  cam_regrid_loc: /any/directory/you/want
+  cam_regrid_loc: /glade/scratch/nusbaume/cam_diag_regrid_files
+
   #Overwrite CAM re-gridded files?
   #If false, then regridding will be skipped for regridded variables
   #that already exist in "cam_regrid_loc":
   cam_overwrite_regrid: false
+
   #Location where CAM diagnostic plots are stored:
-  cam_diag_plot_loc: /any/other/directory/you/want
+  cam_diag_plot_loc: /glade/scratch/nusbaume/cam_diag_plots
 
 #This second set of variables specify whether CAM climatologies need to be calculated:
 diag_cam_climo:
+
   #Calculate cam climatologies?
-  #If false, neither the climatology or time-series files will be created
+  #If false, neither the climatology or time-series files will be created:
   calc_cam_climo: true
+
   #Overwrite CAM climatology files?
-  #If false, then already existing climatology files will be skipped.
+  #If false, then already existing climatology files will be skipped:
   cam_overwrite_climo: false
+
   #Location of CAM history (h0) files:
-  cam_hist_loc: /location/where/you/stored/mode/outputs
+  cam_hist_loc: /glade/scratch/hannay/archive/f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001/atm/hist
+
   #model year when climatology should start:
-  start_year: 1850
+  start_year: 1986
+
   #model year when diagnostics should end:
-  end_year: 2100
+  end_year: 2005
+
   #Save interim time series files?
   #WARNING:  This can take up a significant amount of space:
   cam_ts_save: true
+
   #Overwrite time series files, if found?
   #If set to false, then time series creation will be skipped if files are found:
   cam_overwrite_ts: false
+
   #Location where time series files are (or will be) stored:
-  cam_ts_loc: /some/big/storage/location/to/save/time/series
+  cam_ts_loc: /glade/scratch/nusbaume/cam_diag_ts_files/f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001
 
 #This third set of variables specify whether CAM baseline climatologies need to be calculated
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
+
   #Calculate cam baseline climatologies?
-  #If false, neither the climatology or time-series files will be created
+  #If false, neither the climatology or time-series files will be created:
   calc_cam_climo: true
+
   #Overwrite CAM climatology files?
-  #If false, then already existing climatology files will be skipped.
+  #If false, then already existing climatology files will be skipped:
   cam_overwrite_climo: false
+
   #Location of CAM history (h0) files:
-  cam_hist_loc: /location/of/second/cam/run/output/or/baseline/data
+  cam_hist_loc: /glade/scratch/hannay/archive/f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001/atm/hist
+
   #model year when climatology should start:
-  start_year: 1850
+  start_year: 1986
+
   #model year when diagnostics should end:
-  end_year: 2100
+  end_year: 2005
+
   #Save interim time series files for baseline run?
   #WARNING:  This can take up a significant amount of space:
   cam_ts_save: true
+
   #Overwrite baseline time series files, if found?
   #If set to false, then time series creation will be skipped if files are found:
   cam_overwrite_ts: false
+
   #Location where time series files are (or will be) stored:
-  cam_ts_loc: /another/big/storage/location/to/save/time/series
+  cam_ts_loc: /glade/scratch/nusbaume/cam_diag_ts_files/f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++
 #These variables below only matter if you are using

--- a/config_cam_baseline.yaml
+++ b/config_cam_baseline.yaml
@@ -24,19 +24,19 @@ diag_basic_info:
   obs_climo_loc: /glade/work/brianpm/observations/climo_files
 
   #Name of CAM case (or CAM run name):
-  cam_case_name: f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001
+  cam_case_name: new_best.came-run
 
   #Location of CAM climatologies:
-  cam_climo_loc: /glade/scratch/nusbaume/cam_diag_climo_files/f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001
+  cam_climo_loc: /some/where/you/want/to/have/it
 
   #Name of CAM baseline case (only matters if "compare_obs" is false):
-  cam_baseline_case_name: f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001
+  cam_baseline_case_name: best.cam_run-ever
 
   #Location of baseline CAM cliimatologies (only matters if "compare_obs" is false):
-  cam_baseline_climo_loc: /glade/scratch/nusbaume/cam_diag_climo_files/f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001
+  cam_baseline_climo_loc: /some/where/else/you/want/to/have/it
 
   #Location where re-gridded CAM climatology files are stored:
-  cam_regrid_loc: /glade/scratch/nusbaume/cam_diag_regrid_files
+  cam_regrid_loc: /any/directory/you/want
 
   #Overwrite CAM re-gridded files?
   #If false, then regridding will be skipped for regridded variables
@@ -44,7 +44,8 @@ diag_basic_info:
   cam_overwrite_regrid: false
 
   #Location where CAM diagnostic plots are stored:
-  cam_diag_plot_loc: /glade/scratch/nusbaume/cam_diag_plots
+  cam_diag_plot_loc: /any/other/directory/you/want
+
 
 #This second set of variables specify whether CAM climatologies need to be calculated:
 diag_cam_climo:
@@ -58,7 +59,7 @@ diag_cam_climo:
   cam_overwrite_climo: false
 
   #Location of CAM history (h0) files:
-  cam_hist_loc: /glade/scratch/hannay/archive/f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001/atm/hist
+  cam_hist_loc: /location/where/you/stored/model/outputs
 
   #model year when climatology should start:
   start_year: 1986
@@ -75,7 +76,8 @@ diag_cam_climo:
   cam_overwrite_ts: false
 
   #Location where time series files are (or will be) stored:
-  cam_ts_loc: /glade/scratch/nusbaume/cam_diag_ts_files/f.e21.FWscHIST_BCG.f09_f09_mg17_84L_80kmTop_tau_0_ubc_T.001
+  cam_ts_loc: /some/big/storage/location/to/save/time/series
+
 
 #This third set of variables specify whether CAM baseline climatologies need to be calculated
 #This only matters if "compare_obs" is false:
@@ -90,7 +92,7 @@ diag_cam_baseline_climo:
   cam_overwrite_climo: false
 
   #Location of CAM history (h0) files:
-  cam_hist_loc: /glade/scratch/hannay/archive/f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001/atm/hist
+  cam_hist_loc: /location/of/second/cam/run/output/or/baseline/data
 
   #model year when climatology should start:
   start_year: 1986
@@ -107,7 +109,7 @@ diag_cam_baseline_climo:
   cam_overwrite_ts: false
 
   #Location where time series files are (or will be) stored:
-  cam_ts_loc: /glade/scratch/nusbaume/cam_diag_ts_files/f.e21.FWscHIST_BCG.f09_f09_mg17_110L.001
+  cam_ts_loc: /another/big/storage/location/to/save/time/series
 
 #+++++++++++++++++++++++++++++++++++++++++++++++++++
 #These variables below only matter if you are using

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -15,73 +15,100 @@
 
 #This first set of variables specify basic info required by all diagnostic runs:
 diag_basic_info:
+
   #Is this a model vs observations comparison?
   #If "false", then a model-model comparison is assumed:
   compare_obs: true
+
   #Location of observational climatologies (only matters if "compare_obs" is true):
   #NOTE: How the observational data sets will be managed long-term needs to be discussed at some point!
   obs_climo_loc: /glade/work/brianpm/observations/climo_files
+
   #Name of CAM case (or CAM run name):
   cam_case_name: f2000.v211.fv1d.trop.L42.1
+
   #Location of CAM climatologies:
   cam_climo_loc: /glade/scratch/nusbaume/cam_diag_climo_files/f2000.v211.fv1d.trop.L42.1
+
   #Name of CAM baseline case (only matters if "compare_obs" is false):
   cam_baseline_case_name: best.cam_run-ever
+
   #Location of baseline CAM cliimatologies (only matters if "compare_obs" is false):
   cam_baseline_climo_loc: /some/where/you/want/to/have/it
+
   #Location where re-gridded CAM climatology files are stored:
   cam_regrid_loc: /glade/scratch/nusbaume/cam_diag_regrid_files/f2000.v211.fv1d.trop.L42.1
+
   #Overwrite CAM re-gridded files?
   #If false, then regridding will be skipped for regridded variables
   #that already exist in "cam_regrid_loc":
   cam_overwrite_regrid: true
+
   #Location where CAM diagnostic plots are stored:
   cam_diag_plot_loc: /glade/scratch/nusbaume/cam_diag_plots
 
+
 #This second set of variables specify whether CAM climatologies need to be calculated:
 diag_cam_climo:
+
   #Calculate cam climatologies?
-  #If false, neither the climatology or time-series files will be created
+  #If false, neither the climatology or time-series files will be created:
   calc_cam_climo: true
+
   #Overwrite CAM climatology files?
-  #If false, then already existing climatology files will be skipped.
+  #If false, then already existing climatology files will be skipped:
   cam_overwrite_climo: true
+
   #Location of CAM history (h0) files:
   cam_hist_loc: /glade/scratch/jcaron/archive/f2000.v211.fv1d.trop.L42.1/atm/hist
+
   #model year when climatology should start:
   start_year: 2000
+
   #model year when diagnostics should end:
   end_year: 2010
+
   #Save interim time series files?
   #WARNING:  This can take up a significant amount of space:
   cam_ts_save: true
+
   #Overwrite time series files, if found?
   #If set to false, then time series creation will be skipped if files are found:
   cam_overwrite_ts: false
+
   #Location where time series files are (or will be) stored:
   cam_ts_loc: /glade/scratch/nusbaume/cam_diag_ts_files/f2000.v211.fv1d.trop.L42.1
+
 
 #This third set of variables specify whether CAM baseline climatologies need to be calculated
 #This only matters if "compare_obs" is false:
 diag_cam_baseline_climo:
+
   #Calculate cam baseline climatologies?
-  #If false, neither the climatology or time-series files will be created
+  #If false, neither the climatology or time-series files will be created:
   calc_cam_climo: false
+
   #Overwrite CAM climatology files?
-  #If false, then already existing climatology files will be skipped.
+  #If false, then already existing climatology files will be skipped:
   cam_overwrite_climo: false
+
   #Location of CAM history (h0) files:
   cam_hist_loc: /where/ever/you/want
+
   #model year when climatology should start:
   start_year: 1850
+
   #model year when diagnostics should end:
   end_year: 2100
+
   #Save interim time series files for baseline run?
   #WARNING:  This can take up a significant amount of space:
   cam_ts_save: false
+
   #Overwrite baseline time series files, if found?
   #If set to false, then time series creation will be skipped if files are found:
   cam_overwrite_ts: false
+
   #Location where time series files are (or will be) stored:
   cam_ts_loc: /another/location/on/computer
 


### PR DESCRIPTION
By adding blank lines between the config file variables, and cleaning up the variable description comments some, the example config files should hopefully be easier to read and understand, especially for new users.