### PR TITLE
Flexible function calls

### DIFF
--- a/lib/CamDiag.py
+++ b/lib/CamDiag.py
@@ -434,8 +434,6 @@ class CamDiag:
                 # Arguments; check if user has specified custom arguments
                 avg_func_args = [case_name, input_ts_loc, output_loc, var_list]
                 avg_func_kwargs = {"clobber":overwrite_climo}
-                for localthing in locals():
-                    print(localthing, "\n")
                 if has_opt:
                     if ('args' in opt):
                         # RULES: it has to be a list of strings, and then we will take whatever of those are in locals

--- a/lib/CamDiag.py
+++ b/lib/CamDiag.py
@@ -156,12 +156,12 @@ def construct_index_info(d, fnam, opf):
 
 def function_caller(func_name: str, func_args: list, func_kwargs: dict = {}, module_name=None):
     """Call a function with given arguments.
-    
+
     func_name : string, name of the function to call
     func_args : list, the arguments to pass to the function
     func_kwargs : [optional] dict, the keyword arguments to pass to the function
     module_name : [optional] string, the name of the module where func_name is defined; if not provided, assume func_name.py
-    
+
     return : the output of func_name(*func_args, **func_kwargs)
     """
     if module_name is None:
@@ -401,10 +401,10 @@ class CamDiag:
         if cam_climo_dict['calc_cam_climo']:
 
             #If so, then extract names of time-averaging scripts:
-            avg_func_names = self.__time_averaging_scripts  # this is a list of script names 
-                                                            # _OR_ 
+            avg_func_names = self.__time_averaging_scripts  # this is a list of script names
+                                                            # _OR_
                                                             # a **list** of dictionaries with script names as keys that hold args(list), kwargs(dict), and module(str)
-            
+
             #Extract necessary variables from CAM configure dictionary:
             input_ts_loc    = cam_climo_dict['cam_ts_loc']
             overwrite_climo = cam_climo_dict['cam_overwrite_climo']
@@ -414,7 +414,7 @@ class CamDiag:
             for avg_func_name in avg_func_names:
                 # option to specify the module's name:
                 if isinstance(avg_func_name, dict):
-                    assert len(avg_func_name) == 1, "Function dictionary must be in form: {function_name : {args:[...], <kwargs:{...}>, <module:'xxxx'>}}"
+                    assert len(avg_func_name) == 1, "Function dictionary must be of the form: {function_name : {args:[...], kwargs:{...}, module:'xxxx'}}"
                     has_opt = True
                     opt = avg_func_name[list(avg_func_name.keys())[0]]  # un-nests the dictionary
                     avg_func_name = list(avg_func_name.keys())[0]  # not ideal, but change to a str representation; iteration will continue ok
@@ -456,6 +456,7 @@ class CamDiag:
                         avg_func_kwargs = opt['kwargs']
                 # print(f"DEBUG: \n \t avg_func_name = {avg_func_name}\n \t avg_func_args= {avg_func_args}\n \t avg_kwargs= {avg_func_kwargs}")
                 # This print statement should be added to a debug log. Provides information about the parsing of the function and arguments.
+                print(avg_func_kwargs.items())
                 function_caller(avg_func_name, avg_func_args, func_kwargs=avg_func_kwargs, module_name=avg_func_name)
         else:
             #If not, then notify user that climo file generation is skipped.
@@ -506,7 +507,7 @@ class CamDiag:
         for regrid_func_name in regrid_func_names:
             # option to specify the module's name:
             if isinstance(regrid_func_name, dict):
-                assert len(avg_func_name) == 1, "Regrid function dictionary must be in form: {function_name : {args:[...], <kwargs:{...}>, <module:'xxxx'>}}"
+                assert len(avg_func_name) == 1, "Regrid function dictionary must be of the form: {function_name : {args:[...], kwargs:{...}, module:'xxxx'}}"
                 has_opt = True
                 opt = regrid_func_name[list(regrid_func_name.keys())[0]]  # un-nests the dictionary
                 regrid_func_name = list(regrid_func_name.keys())[0]  # not ideal, but change to a str representation; iteration will continue ok
@@ -591,7 +592,7 @@ class CamDiag:
         #Loop over all averaging script names:
         for anly_func_name in anly_func_names:
             if isinstance(anly_func_name, dict):
-                assert len(anly_func_name) == 1, "Function dictionary must be in form: {function_name : {args:[...], <kwargs:{...}>, <module:'xxxx'>}}"
+                assert len(anly_func_name) == 1, "Function dictionary must be of the form: {function_name : {args:[...], kwargs:{...}, module:'xxxx'}}"
                 has_opt = True
                 opt = anly_func_name[list(anly_func_name.keys())[0]]  # un-nests the dictionary
                 anly_func_name = list(anly_func_name.keys())[0]  # not ideal, but change to a str representation; iteration will continue ok
@@ -676,7 +677,7 @@ class CamDiag:
         #Loop over all re-gridding script names:
         for plot_func_name in plot_func_names:
             if isinstance(plot_func_name, dict):
-                assert len(plot_func_name) == 1, "Function dictionary must be in form: {function_name : {args:[...], <kwargs:{...}>, <module:'xxxx'>}}"
+                assert len(plot_func_name) == 1, "Function dictionary must be of the form: {function_name : {args:[...], kwargs:{...}, module:'xxxx'}}"
                 has_opt = True
                 opt = plot_func_name[list(plot_func_name.keys())[0]]  # un-nests the dictionary
                 plot_func_name = list(plot_func_name.keys())[0]  # not ideal, but change to a str representation; iteration will continue ok

--- a/lib/CamDiag.py
+++ b/lib/CamDiag.py
@@ -305,18 +305,27 @@ class CamDiag:
             #Create path object for the CAM history file(s) location:
             starting_location = Path(cam_climo_dict['cam_hist_loc'])
 
-            #Create empty list:
-            files_list = list()
+            #Check that path actually exists:
+            if not starting_location.is_dir():
+                if baseline:
+                    msg = "Provided baseline 'cam_hist_loc' directory '{}' not found.  Script is ending here."
+                else:
+                    msg = "Provided 'cam_hist_loc' directory '{}' not found.  Script is ending here."
+                msg = msg.format(starting_location)
+                end_diag_script(msg)
 
             #Check if history files actually exist. If not then kill script:
-            if not starting_location.glob('*.cam.h0.*.nc'):
+            if not list(starting_location.glob('*.cam.h0.*.nc')):
                 msg = "No CAM history (h0) files found in '{}'.  Script is ending here."
                 msg = msg.format(starting_location)
                 end_diag_script(msg)
 
+            #Create empty list:
+            files_list = list()
+
             #Loop over start and end years:
             for year in range(start_year, end_year+1):
-                #Add files to main file list:
+                #Try adding files to main file list:
                 for fname in starting_location.glob('*.cam.h0.*{}-*.nc'.format(year)):
                     files_list.append(fname)
 
@@ -428,7 +437,7 @@ class CamDiag:
                     print(f"[INFO] Inserting to sys.path: {avg_script_path}")  # Should go into a log file
                     sys.path.insert(0, avg_script_path)
                 # NOTE: when we move to making this into a proper package, this path-checking stuff should be removed and dealt with on the package-level.
-                    
+
                 # Arguments; check if user has specified custom arguments
                 avg_func_args = [case_name, input_ts_loc, output_loc, var_list]
                 avg_func_kwargs = {"clobber":overwrite_climo}
@@ -436,7 +445,7 @@ class CamDiag:
                     if ('args' in opt):
                         # RULES: it has to be a list of strings, and then we will take whatever of those are in locals
                         assert isinstance(opt['args'], list), "Function arguments must be of type list."
-                        assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type list."
+                        assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type string."
                         avg_func_args = list()  # start over
                         for variableToCheck in opt['args']:
                             if variableToCheck in locals():
@@ -488,10 +497,10 @@ class CamDiag:
         var_list         = self.__diag_var_list
 
         #Extract names of re-gridding scripts:
-        regrid_func_names = self.__regridding_scripts  # this is a list of script names 
-                                                       # _OR_ 
+        regrid_func_names = self.__regridding_scripts  # this is a list of script names
+                                                       # _OR_
                                                        # a **list** of dictionaries with script names as keys that hold args(list), kwargs(dict), and module(str)
-            
+
 
         #Loop over all re-gridding script names:
         for regrid_func_name in regrid_func_names:
@@ -518,16 +527,16 @@ class CamDiag:
                 msg = "Regridding file '{}' is missing. Script is ending here.".format(regrid_script_path)
                 end_diag_script(msg)
             if regrid_script_path not in sys.path:
-                print(f"[INFO] Inserting to sys.path: {avg_script_path}") # Should go into a log file
+                print(f"[INFO] Inserting to sys.path: {regrid_script_path}") # Should go into a log file
                 sys.path.insert(0, regrid_script_path)
-                
+
             regrid_func_args = [case_name, input_climo_loc, output_loc, var_list, target_list, target_loc, overwrite_regrid]
             regrid_func_kwargs = {}
             if has_opt:
                 if ('args' in opt):
                     # RULES: it has to be a list of strings, and then we will take whatever of those are in locals
                     assert isinstance(opt['args'], list), "Function arguments must be of type list."
-                    assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type list."
+                    assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type string."
                     regrid_func_args = list()  # start over
                     for variableToCheck in opt['args']:
                         if variableToCheck in locals():
@@ -551,10 +560,10 @@ class CamDiag:
         """
 
         #Extract names of plotting scripts:
-        anly_func_names = self.__analysis_scripts  # this is a list of script names 
-                                                   # _OR_ 
+        anly_func_names = self.__analysis_scripts  # this is a list of script names
+                                                   # _OR_
                                                    # a **list** of dictionaries with script names as keys that hold args(list), kwargs(dict), and module(str)
-            
+
         #If no scripts are listed, then exit routine:
         if not anly_func_names:
             print("Nothing listed under 'analysis_scripts', so no plots will be made.")
@@ -611,7 +620,7 @@ class CamDiag:
                 if ('args' in opt):
                     # RULES: it has to be a list of strings, and then we will take whatever of those are in locals
                     assert isinstance(opt['args'], list), "Function arguments must be of type list."
-                    assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type list."
+                    assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type string."
                     anly_func_args = list()  # start over
                     for variableToCheck in opt['args']:
                         if variableToCheck in locals():
@@ -638,8 +647,8 @@ class CamDiag:
         """
 
         #Extract names of plotting scripts:
-        plot_func_names = self.__plotting_scripts  # this is a list of script names 
-                                                   # _OR_ 
+        plot_func_names = self.__plotting_scripts  # this is a list of script names
+                                                   # _OR_
                                                    # a **list** of dictionaries with script names as keys that hold args(list), kwargs(dict), and module(str)
 
 
@@ -673,7 +682,7 @@ class CamDiag:
                 plot_func_name = list(plot_func_name.keys())[0]  # not ideal, but change to a str representation; iteration will continue ok
             else:
                 has_opt = False
-            
+
             plot_script = plot_func_name+'.py'  # Add file suffix to script name (to help with the file search)
             if has_opt:
                 if 'module' in opt:
@@ -697,7 +706,7 @@ class CamDiag:
                 if ('args' in opt):
                     # RULES: it has to be a list of strings, and then we will take whatever of those are in locals
                     assert isinstance(opt['args'], list), "Function arguments must be of type list."
-                    assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type list."
+                    assert all(isinstance(item, str) for item in opt['args']), "Function argument list elements must be of type string."
                     plot_func_args = list()  # start over
                     for variableToCheck in opt['args']:
                         if variableToCheck in locals():
@@ -705,7 +714,7 @@ class CamDiag:
                         else:
                             print("{} is not available".format(variableToCheck))
                 if 'kwargs' in opt:
-                    avg_func_kwargs = opt['kwargs']            
+                    avg_func_kwargs = opt['kwargs']
             function_caller(plot_func_name, plot_func_args, func_kwargs=plot_func_kwargs, module_name=plot_func_name+'.py')
 
     #########

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -98,7 +98,8 @@ def amwg_table(case_name, input_ts_loc, output_loc, var_list, write_html):
     if not input_location.is_dir():
         errmsg = "Time series directory '{}' not found.  Script is exiting.".format(input_ts_loc)
         end_diag_script(errmsg)
-    print(f"DEBUG: location of files is {str(input_location)}")
+    # print(f"DEBUG: location of files is {str(input_location)}")
+    # TODO: add location of files to debug log
     #Check if analysis directory exists, and if not, then create it:
     if not output_location.is_dir():
         print("    {} not found, making new directory".format(output_loc))

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -48,7 +48,7 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, clobber=Fal
 
     # Time series file search
     if search is None:
-        search = "{CASE}*.{VARIABLE}.*.nc"
+        search = "{CASE}*.{VARIABLE}.nc"
 
     #Loop over CAM output variables:
     for var in var_list:

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -1,5 +1,4 @@
-def averaging_example(case_name, input_ts_loc, output_loc, var_list, search=None):
-
+def averaging_example(case_name, input_ts_loc, output_loc, var_list, clobber=False, search=None):
     """
     This is an example function showing
     how to set-up a time-averaging method
@@ -13,17 +12,22 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, search=None
     output_loc   -> Location to write CAM climo files to, provided by "cam_climo_loc"
     var_list     -> List of CAM output variables provided by "diag_var_list"
 
-    search -> optional; if supplied requires a string used as a template to find the time series files
-              using {CASE} and {VARIABLE} and otherwise an arbitrary shell-like globbing pattern:
-              example 1: provide the string "{CASE}.*.{VARIABLE}.*.nc" this is the default
-              example 2: maybe CASE is not necessary because post-process destroyed the info "post_process_text-{VARIABLE}.nc"
-              example 3: order does not matter "{VARIABLE}.{CASE}.*.nc"
-              Only CASE and VARIABLE are allowed because they are arguments to the averaging function
+    keyword arguments
+        clobber -> whether to overwrite existing climatology files. Defaults to False (do not delete).
+
+        search  -> optional; if supplied requires a string used as a template to find the time series files
+                using {CASE} and {VARIABLE} and otherwise an arbitrary shell-like globbing pattern:
+                example 1: provide the string "{CASE}.*.{VARIABLE}.*.nc" this is the default
+                example 2: maybe CASE is not necessary because post-process destroyed the info "post_process_text-{VARIABLE}.nc"
+                example 3: order does not matter "{VARIABLE}.{CASE}.*.nc"
+                Only CASE and VARIABLE are allowed because they are arguments to the averaging function
     """
 
     #Import necessary modules:
     import xarray as xr
     from pathlib import Path
+    from CamDiag import end_diag_script
+    import warnings  # use to warn user about missing files.
 
     #Notify user that script has started:
     print("  Calculating CAM climatologies...")
@@ -48,15 +52,23 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, search=None
 
     #Loop over CAM output variables:
     for var in var_list:
+        # Create name of climatology output file (which includes the full path)
+        # and check whether it is there (don't do computation if we don't want to overwrite):
+        output_file = output_location / "{}_{}_climo.nc".format(case_name,var)
+        if (not clobber) and (output_file.is_file()):
+            print("INFO: Found climo file and clobber is False, so skipping to next variable.")
+            continue
 
         #Create list of time series files present for variable:
         ts_filenames = search.format(CASE=case_name, VARIABLE=var)
         ts_files = sorted(list(input_location.glob(ts_filenames)))
 
-        #If no files exist, then kill diagnostics script (for now):
+        # If no files exist, try to move to next variable. --> Means we can not proceed with this variable, and it'll be problematic later.
         if not ts_files:
-             errmsg = "Time series files for variable '{}' not found.  Script is exiting.".format(var)
-             end_diag_script(errmsg)
+            errmsg = "Time series files for variable '{}' not found.  Script will continue to next variable.".format(var)
+            #  end_diag_script(errmsg) # Previously we would kill the run here.
+            warnings.warn(errmsg)
+            continue
 
         #Read in files via xarray (xr):
         if len(ts_files) == 1:
@@ -67,7 +79,7 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, search=None
         #Average time dimension over time bounds, if bounds exist:
         if 'time_bnds' in cam_ts_data:
             time = cam_ts_data['time']
-            time = xr.DataArray(cam_ts_data['time_bnds'].mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)
+            time = xr.DataArray(cam_ts_data['time_bnds'].load().mean(dim='nbnd').values, dims=time.dims, attrs=time.attrs)  # NOTE: force `load` here b/c if dask & time is cftime, throws a NotImplementedError
             cam_ts_data['time'] = time
             cam_ts_data.assign_coords(time=time)
             cam_ts_data = xr.decode_cf(cam_ts_data)
@@ -78,8 +90,7 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, search=None
         #Rename "months" to "time":
         cam_climo_data = cam_climo_data.rename({'month':'time'})
 
-        #Create name of climatology output file (which includes the full path):
-        output_file = output_location / "{}_{}_climo.nc".format(case_name,var)
+
 
         #Set netCDF encoding method (deal with getting non-nan fill values):
         enc_dv = {xname: {'_FillValue': None, 'zlib': True, 'complevel': 4} for xname in cam_climo_data.data_vars}

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -1,4 +1,4 @@
-def averaging_example(case_name, input_ts_loc, output_loc, var_list):
+def averaging_example(case_name, input_ts_loc, output_loc, var_list, search=None):
 
     """
     This is an example function showing
@@ -12,6 +12,13 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list):
     input_ts_loc -> Location of CAM time series files provided by "cam_ts_loc"
     output_loc   -> Location to write CAM climo files to, provided by "cam_climo_loc"
     var_list     -> List of CAM output variables provided by "diag_var_list"
+
+    search -> optional; if supplied requires a string used as a template to find the time series files
+              using {CASE} and {VARIABLE} and otherwise an arbitrary shell-like globbing pattern:
+              example 1: provide the string "{CASE}.*.{VARIABLE}.*.nc" this is the default
+              example 2: maybe CASE is not necessary because post-process destroyed the info "post_process_text-{VARIABLE}.nc"
+              example 3: order does not matter "{VARIABLE}.{CASE}.*.nc"
+              Only CASE and VARIABLE are allowed because they are arguments to the averaging function
     """
 
     #Import necessary modules:
@@ -35,11 +42,15 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list):
         print("    {} not found, making new directory".format(output_loc))
         output_location.mkdir(parents=True)
 
+    # Time series file search
+    if search is None:
+        search = "{CASE}*.{VARIABLE}.*.nc"
+
     #Loop over CAM output variables:
     for var in var_list:
 
         #Create list of time series files present for variable:
-        ts_filenames = '{}.*{}*.nc'.format(case_name, var)
+        ts_filenames = search.format(CASE=case_name, VARIABLE=var)
         ts_files = sorted(list(input_location.glob(ts_filenames)))
 
         #If no files exist, then kill diagnostics script (for now):

--- a/scripts/regridding/regrid_example.py
+++ b/scripts/regridding/regrid_example.py
@@ -58,7 +58,7 @@ def regrid_example(case_name, input_climo_loc, output_loc,
 
         #loop over regridding targets:
         for target in target_list:
-            print(f"DEBUG: target = {target}")
+            # print(f"DEBUG: target = {target}") #TODO: add to debug log.
             #Determine regridded variable file name:
             regridded_file_loc = rgclimo_loc / '{}_{}_{}_regridded.nc'.format(target, case_name, var)
 
@@ -73,7 +73,7 @@ def regrid_example(case_name, input_climo_loc, output_loc,
                 #Create list of regridding target files (we should explore intake as an alternative to having this kind of repeated code)
                 # NOTE: This breaks if you have files from different cases in same directory!
                 tclim_fils = sorted(list(tclimo_loc.glob("{}*_{}_*.nc".format(target, var))))
-                print(f"DEBUG: tclim_fils (n={len(tclim_fils)}): {tclim_fils}")
+                # print(f"DEBUG: tclim_fils (n={len(tclim_fils)}): {tclim_fils}") # TODO: add to debug log
             
                 if len(tclim_fils) > 1:
                     #Combine all target files together into a single data set:

--- a/scripts/regridding/regrid_example.py
+++ b/scripts/regridding/regrid_example.py
@@ -58,7 +58,7 @@ def regrid_example(case_name, input_climo_loc, output_loc,
 
         #loop over regridding targets:
         for target in target_list:
-
+            print(f"DEBUG: target = {target}")
             #Determine regridded variable file name:
             regridded_file_loc = rgclimo_loc / '{}_{}_{}_regridded.nc'.format(target, case_name, var)
 
@@ -71,11 +71,16 @@ def regrid_example(case_name, input_climo_loc, output_loc,
             if not regridded_file_loc.is_file():
 
                 #Create list of regridding target files (we should explore intake as an alternative to having this kind of repeated code)
+                # NOTE: This breaks if you have files from different cases in same directory!
                 tclim_fils = sorted(list(tclimo_loc.glob("{}*_{}_*.nc".format(target, var))))
-
+                print(f"DEBUG: tclim_fils (n={len(tclim_fils)}): {tclim_fils}")
+            
                 if len(tclim_fils) > 1:
                     #Combine all target files together into a single data set:
                     tclim_ds = xr.open_mfdataset(tclim_fils, combine='by_coords')
+                elif len(tclim_fils) == 0:
+                    print("\t [\u25B6] regridding {} failed, no file. Continuing to next variable.".format(var))
+                    continue
                 else:
                     #Open single file as new xarray dataset:
                     tclim_ds = xr.open_dataset(tclim_fils[0])


### PR DESCRIPTION
These changes are mainly focused on providing a more flexible way to call the functions that are inside the `scripts` directory. A new function called `function_caller` is added to `CamDiag`. 

As a way to test this, I also modified how the yaml file is treated. I allowed averaging scripts to be a nested dict, not just a list of functions. This allows the user to provide a list of args and kwargs as strings, and then we inspect `locals` to find out if they are actually variables. I'm not sure if this is robust, but it at least worked for my tests so far.

Other changes are part of my attempt to test this capability. I was using two CAM simulations that only have time series files, not history files. Skipping the time series file creation required some modifications. I also modified code to try to keep going if a variable is not found (used `warnings` for when that happens).

Oh, and I just realized I left a bunch of debugging/print statements in there, which should be deleted. 

Sorry for the messy-ness of this PR. Let me know if you have trouble extracting the useful parts.

Fixes #6 