### PR TITLE
Re-factor ADF library classes

### DIFF
--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -1,0 +1,30 @@
+name: Pull Request (PR) open and sync workflow
+
+on:
+  pull_request:
+   types: [opened, synchronize, reopened]
+
+jobs:
+  #This job is designed to run all python unit tests whenever
+  #a PR is either opened or synced (i.e. additional commits are pushed
+  #to branch involved in PR).
+  python_unit_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        #All of these python versions will be used to run tests:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+    steps:
+    # Acquire github action routines:
+    - uses: actions/checkout@v2
+    # Acquire specific version of python:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    # Run python unit tests:
+    - name: python unit tests
+      run: |
+        #AdfBase unittests:
+        python lib/unit_tests/test_adfbase.py
+

--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -25,6 +25,7 @@ jobs:
     # Run python unit tests:
     - name: python unit tests
       run: |
-        #AdfBase unittests:
+        #AdfBase unit tests:
         python lib/unit_tests/test_adfbase.py
-
+        #AdfConfig unit tests:
+        python lib/unit_tests/test_adfconfig.py

--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         #All of these python versions will be used to run tests:
         python-version: [3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
     steps:
     # Acquire github action routines:
     - uses: actions/checkout@v2

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -108,6 +108,12 @@ diag_cam_climo:
   #       end at latest available year.
   end_year: 2100
 
+  #Do time series files need to be generated?
+  #If True, then diagnostics assumes that model files are already time series.
+  #If False, or if simply not present, then diagnostics will attempt to create
+  #time series files from history (time-slice) files:
+  cam_ts_done: false
+
   #Save interim time series files?
   #WARNING:  This can take up a significant amount of space:
   cam_ts_save: true
@@ -144,6 +150,12 @@ diag_cam_baseline_climo:
   #Note:  Leaving this entry blank will make diagnostics
   #       end at latest available year.
   end_year: 2100
+
+  #Do time series files need to be generated?
+  #If True, then diagnostics assumes that model files are already time series.
+  #If False, or if simply not present, then diagnostics will attempt to create
+  #time series files from history (time-slice) files:
+  cam_ts_done: false
 
   #Save interim time series files for baseline run?
   #WARNING:  This can take up a significant amount of space:

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -40,7 +40,9 @@
 #
 #Please note that for both 1 and 2 the keywords must be lowercase.
 #This is because future developments will hopefully use other keywords
-#that are uppercase.
+#that are uppercase. Also please avoid using periods (".") in variable
+#names, as this will likely cause issues with the current file parsing
+#system.
 #--------------------
 #
 ##==============================

--- a/lib/AdfBase.py
+++ b/lib/AdfBase.py
@@ -1,0 +1,81 @@
+"""
+Base class for the Atmospheric 
+Diagnostics Framework (ADF).  All
+other ADF classes inherit from this
+class.
+
+Currently this class only does two things:
+
+1.  Creates a debug logger, if requested.
+
+2.  Defines an ADF-specific function to end
+    the diagnostics program, if need be.
+"""
+
+#++++++++++++++++++++++++++++++
+#Import standard python modules
+#++++++++++++++++++++++++++++++
+
+import logging
+
+#+++++++++++++++++++++++++
+# ADF Error-handling class
+#+++++++++++++++++++++++++
+
+class AdfError(RuntimeError):
+    """Class used to handle ADF value errors
+    (e.g., log user errors without backtrace)"""
+    pass
+
+#+++++++++++++++++
+#Define base class
+#+++++++++++++++++
+
+class AdfBase:
+
+    """
+    Base class for the ADF
+    """
+
+    def __init__(self, debug = False):
+
+        """
+        Initalize CAM diagnostics object.
+        """
+
+        # Check that debug is in fact a boolean,
+        # in order to avoid accidental boolean evaluation:
+        if not isinstance(debug, bool):
+            raise TypeError("'debug' must be a boolean type (True or False)")
+
+        # Create debug log, if requested:
+        if debug:
+            logging.basicConfig(filename="ADF_debug.log", level=logging.DEBUG)
+            self.__debug_log = logging.getLogger("ADF")
+        else:
+            self.__debug_log = None
+
+    #########
+
+    def debug_log(self, msg: str):
+
+        """
+        Write message to debug log, if enabled.
+        """
+
+        #If debug log exists, then write message to log:
+        if self.__debug_log:
+            self.__debug_log.debug(msg)
+
+    #########
+
+    def end_diag_fail(self, msg: str):
+
+        """
+        Prints message, and then exits program
+        with an Adf-specific error.
+        """
+
+        print("\n")
+        raise AdfError(msg)
+

--- a/lib/AdfBase.py
+++ b/lib/AdfBase.py
@@ -1,5 +1,5 @@
 """
-Base class for the Atmospheric 
+Base class for the Atmospheric
 Diagnostics Framework (ADF).  All
 other ADF classes inherit from this
 class.

--- a/lib/AdfConfig.py
+++ b/lib/AdfConfig.py
@@ -39,7 +39,7 @@ class AdfConfig(AdfBase):
     relevant config variables.
     """
 
-    def __init__(self, config_file, debug = False):
+    def __init__(self, config_file, debug=False):
 
         """
         Initalize ADF Config object.

--- a/lib/AdfConfig.py
+++ b/lib/AdfConfig.py
@@ -1,0 +1,288 @@
+"""
+Config class for the Atmospheric
+Diagnostics Framework (ADF).
+This class inherits from the AdfBase class.
+
+Currently this class does three things:
+
+1.  Initializes and instance of AdfBase.
+
+2.  Reads in a config (YAML) file.
+
+3.  Expands any keywords into their relevant variable values.
+"""
+
+#++++++++++++++++++++++++++++++
+#Import standard python modules
+#++++++++++++++++++++++++++++++
+
+import os.path
+import re
+
+#+++++++++++++++++++++++++++++++++++++++++++++++++
+#import non-standard python modules, including ADF
+#+++++++++++++++++++++++++++++++++++++++++++++++++
+
+import yaml
+from AdfBase import AdfBase
+
+#+++++++++++++++++++
+#Define config class
+#+++++++++++++++++++
+
+class AdfConfig(AdfBase):
+
+    """
+    Config class, which reads in
+    config (YAML) files and provides
+    a mechanism to process and retreive
+    relevant config variables.
+    """
+
+    def __init__(self, config_file, debug = False):
+
+        """
+        Initalize ADF Config object.
+        """
+
+        #Initialize Base attributes:
+        super(AdfConfig, self).__init__(debug=debug)
+
+        #Expand any environmental user name variables in the path:
+        config_file = os.path.expanduser(config_file)
+
+        #Check that YAML file actually exists:
+        if not os.path.exists(config_file):
+            emsg = f"File '{config_file}' not found. Please provide full path."
+            raise FileNotFoundError(emsg)
+
+        #Open YAML file:
+        with open(config_file) as nfil:
+            #Load YAML file:
+            self.__config_dict = yaml.load(nfil, Loader=yaml.SafeLoader)
+
+        #Create search dictionary for variable expansion:
+        self.__search_dict = self.__create_search_dict(self.__config_dict)
+
+        #Create YAML self-reference keyword regex:
+        self.__kword_pattern = re.compile(r'\$\{[a-z_\.\d]+\}')
+
+    #########
+
+    def __create_search_dict(self, config_dict, sub_dict=None):
+
+        """
+        Recursive function that creates a non-hierarchical
+        dictionary for use in global key/value searches.
+
+        Please note that PyYAML doesn't allow for multiple
+        variables in the same dictionary, so no need to check
+        here.
+        """
+
+        #Create empty dictionary:
+        config_search_dict = dict()
+
+        #Loop over all top-level config variables:
+        for key, value in config_dict.items():
+
+            #Check if value is a string, integer, or another dict:
+            if isinstance(value, str) or isinstance(value, int):
+
+                #Check if sub dictionary is present:
+                if sub_dict:
+                    #Create new key with sub dictionary prefix:
+                    key = sub_dict+"."+key
+
+                #Add key/value to search dict:
+                config_search_dict[key] = str(value)
+
+            #Check if value is a dictionary instead:
+            elif isinstance(value, dict):
+                #Currently this routine only handles one level of
+                #nested dictionaries, so throw an error if one has
+                #gone beyond that:
+                if sub_dict:
+                    ermsg = "ADF currently only allows for a single nested dict"
+                    ermsg += f" in the config (YAML) file.\n  Variable '{value}' is nested too far."
+                    self.end_diag_fail(ermsg)
+
+                #Apply routine to sub dictionary:
+                sub_config_search_dict = self.__create_search_dict(value,
+                                                                 sub_dict = key)
+
+                #Append sub-dict search dictionary to top-level dictionary:
+                config_search_dict.update(sub_config_search_dict)
+
+        #Return search dictionary:
+        return config_search_dict
+
+    #########
+
+    def __expand_yaml_var_ref(self, var_val):
+
+        """
+        Recursive function to replace all keywords with their
+        associated values from the provided dictionary.
+        """
+
+        #If variable value is not a string, then convert it:
+        if not isinstance(var_val, str):
+            var_val = str(var_val)
+
+        #Look for keyword using provided regular expression:
+        kword_match = self.__kword_pattern.search(var_val)
+
+        #Continue if at least one match is found:
+        if kword_match:
+
+            #Copy input variable value string,
+            #which is needed for generating
+            #proper error messages:
+            new_var_val = var_val
+
+            #Start while loop:
+            another_match = True
+
+            while another_match:
+
+                #Extract match string:
+                kword_match_str = kword_match.group(0)
+
+                #Remove special characters ("${" and "}"):
+                kword_match_str = kword_match_str[2:-1]
+
+                #Initalize kword_match_str_key value:
+                kword_match_str_key = kword_match_str
+
+                #Check if period (".") is in string,
+                #If so, then the keyword will be used directly,
+                #otherwise do the following:
+                #--------------------------
+                if kword_match_str.find(".") == -1:
+
+                    #Initalize match counter:
+                    match_count = 0
+
+                    #Loop through search dictionary keys:
+                    for key in self.__search_dict.keys():
+
+                        #Attempt to find period string index:
+                        pidx = key.find(".")
+
+                        #Compare kword to text on the right side of period
+                        #or at start of string if no period exists:
+                        if kword_match_str == key[pidx+1:]:
+                            #Set match string to full key string:
+                            kword_match_str_key = key
+
+                            #Add one to counter:
+                            match_count += 1
+
+                    #If more than one match, then throw an error:
+                    if match_count > 1:
+                        ermsg = f"More than one variable matches keyword '{var_val}'"
+                        ermsg += "\nPlease use '${section.variable}' keyword method to specify"
+                        ermsg += " which variable you want to use."
+                        self.end_diag_fail(ermsg)
+                #--------------------------
+
+                #Throw an error if keyword not in dictionary:
+                if kword_match_str_key not in self.__search_dict.keys():
+                    ermsg = f"ERROR: Variable '{kword_match_str}'"
+                    ermsg += " not found in config (YAML) file."
+                    self.end_diag_fail(ermsg)
+
+                #Extract keyword value from config dictionary:
+                kword_val = self.__search_dict[kword_match_str_key]
+
+                #Expand keyword if found:
+                final_kword_val = self.__expand_yaml_var_ref(kword_val)
+
+                #Substitute keyword with final kword_val:
+                new_var_val = new_var_val[:kword_match.start()] + final_kword_val + new_var_val[kword_match.end():]
+
+                #Search the string again for keyword values:
+                kword_match = self.__kword_pattern.search(new_var_val)
+
+                #End loop if no other matches found:
+                if not kword_match:
+                    another_match = False
+
+            #End while loop
+
+            #Pass back final value:
+            return new_var_val
+
+        else:
+            #Return the string un-modified:
+            return var_val
+
+    #########
+
+    def expand_references(self, config_dict):
+
+        """
+        Replace keyword (${var} or ${dict.var}) entries
+        in the YAML (config) dictionary that reference
+        other YAML dictionary variables/keys with the
+        values of those variables.
+
+        Currently this function will always convert the
+        referenced variable to a string.
+        """
+
+        #copy YAML config dictionary:
+        config_dict_copy = config_dict
+
+        #Loop through dictionary:
+        for key, value in config_dict_copy.items():
+
+            #Skipe non-strings (as they won't contain a keyword):
+            if not isinstance(value, str):
+                continue
+
+            #expand any keywords to their full values:
+            new_value = self.__expand_yaml_var_ref(value)
+
+            #Set config variable to new, expanded value:
+            config_dict[key] = new_value
+
+    #########
+
+    def read_config_var(self, varname, conf_dict=None):
+
+        """
+        Checks if variable/list/dictionary exists in
+        configure dictionary,and if so returns it.
+        """
+
+        #Check if the config dictionary has been specified:
+        if isinstance(conf_dict, dict):
+            var_dict = conf_dict
+        elif isinstance(conf_dict, type(None)):
+            var_dict = self.__config_dict
+        else:
+            emsg = f"Supplied 'conf_dict' variable should be a dictionary, not type '{type(conf_dict)}'"
+            raise TypeError(emsg)
+
+        #Check that variable name exists in dictionary:
+        if varname not in var_dict.keys():
+            emsg = f"Variable '{varname}' not found in config file.  Please see 'config_cam_baseline_example.yaml'."
+            raise KeyError(emsg)
+
+        #Extract variable from dictionary:
+        var = var_dict[varname]
+
+        #Check that configure variable is not empty (None):
+        if var is None:
+            emsg = f"Variable '{varname}' has not been set to a value. Please see 'config_cam_baseline_example.yaml'."
+            raise ValueError(emsg)
+
+        #return variable/list/dictionary:
+        return var
+
+#####################
+#End Class definition
+#####################
+

--- a/lib/AdfDiag.py
+++ b/lib/AdfDiag.py
@@ -17,8 +17,6 @@ import os.path
 import glob
 import subprocess
 import importlib
-import logging
-import re
 
 from pathlib import Path
 
@@ -63,7 +61,7 @@ except ImportError:
     sys.exit(1)
 
 #+++++++++++++++++++++++++++++
-#Add Cam diagnostics 'scripts'
+#Add ADF diagnostics 'scripts'
 #directories to Python path
 #+++++++++++++++++++++++++++++
 
@@ -76,7 +74,7 @@ _DIAG_SCRIPTS_PATH = os.path.join(_LOCAL_PATH,os.pardir,"scripts")
 #Check that "scripts" directory actually exists:
 if not os.path.isdir(_DIAG_SCRIPTS_PATH):
     #If not, then raise error:
-    raise FileNotFoundError("'{}' directory not found. Has 'CamDiag.py' been moved?".format(_DIAG_SCRIPTS_PATH))
+    raise FileNotFoundError("'{}' directory not found. Has 'AdfDiag.py' been moved?".format(_DIAG_SCRIPTS_PATH))
 
 #Walk through all sub-directories in "scripts" directory:
 for root, dirs, files in os.walk(_DIAG_SCRIPTS_PATH):
@@ -84,47 +82,14 @@ for root, dirs, files in os.walk(_DIAG_SCRIPTS_PATH):
     for dirname in dirs:
         sys.path.append(os.path.join(root,dirname))
 
+#+++++++++++++++++++++++++++++
+
+#Finally, import needed ADF modules:
+from AdfConfig import AdfConfig
+
 #################
 #Helper functions
 #################
-
-#++++++++++++++++++++++++++++++++
-#Script message and exit function
-#++++++++++++++++++++++++++++++++
-
-def end_diag_script(msg):
-
-    """
-    Prints message, and then exits script.
-    """
-
-    print("\n")
-    print(msg)
-    sys.exit(1)
-
-#####
-
-def read_config_obj(config_obj, varname):
-
-    """
-    Checks if variable/list/dictionary exists in
-    configure object,and if so returns it.
-    """
-
-    #Attempt to read in YAML config variable:
-    try:
-        var = config_obj[varname]
-    except:
-       raise KeyError("'{}' not found in config file.  Please see 'config_cam_baseline_example.yaml'.".format(varname))
-
-    #Check that configure variable is not empty (None):
-    if var is None:
-        raise NameError("'{}' has not been set to a value. Please see 'config_cam_baseline_example.yaml'.".format(varname))
-
-    #return variable/list/dictionary:
-    return var
-
-#####
 
 def construct_index_info(d, fnam, opf):
 
@@ -154,19 +119,17 @@ def construct_index_info(d, fnam, opf):
         d[vname][plot_type] = {}
     d[vname][plot_type][temporal] = opf
 
-#####
-
 ######################################
 #Main CAM diagnostics class (CamDiag)
 ######################################
 
-class CamDiag:
+class AdfDiag(AdfConfig):
 
     """
-    Main CAM diagnostics object.
+    Main ADF diagnostics object.
 
     This object is initalized using
-    a CAM diagnostics configure (YAML) file,
+    an ADF diagnostics configure (YAML) file,
     which specifies various user inputs,
     including CAM history file names and
     locations, years being analyzed,
@@ -186,66 +149,46 @@ class CamDiag:
         Initalize CAM diagnostics object.
         """
 
-        #Create debug log, if requested:
-        if debug:
-            logging.basicConfig(filename="cam_diag_debug.log", level=logging.DEBUG)
-            self.__debug_log = logging.getLogger("CamDiag")
-            self.__debug = True
-        else:
-            self.__debug = False
-
-        #Expand any environmental user name variables in the path:
-        config_file = os.path.expanduser(config_file)
-
-        #Check that YAML file actually exists:
-        if not os.path.exists(config_file):
-            raise FileNotFoundError("'{}' file not found.".format(config_file))
-
-        #Open YAML file:
-        with open(config_file) as nfil:
-            #Load YAML file:
-            config = yaml.load(nfil, Loader=yaml.SafeLoader)
-
-        #Combine top-level dictionaries into one to allow searching:
-        config_search_dict = self.__create_search_dict(config)
+        #Initialize Config/Base attributes:
+        super(AdfDiag, self).__init__(config_file, debug=debug)
 
         #Add basic diagnostic info to object:
-        self.__basic_info = read_config_obj(config, 'diag_basic_info')
+        self.__basic_info = self.read_config_var('diag_basic_info')
 
         #Expand basic info variable strings:
-        self.__expand_references(self.__basic_info, config_search_dict)
+        self.expand_references(self.__basic_info)
 
         #Add CAM climatology info to object:
-        self.__cam_climo_info = read_config_obj(config, 'diag_cam_climo')
+        self.__cam_climo_info = self.read_config_var('diag_cam_climo')
 
         #Expand CAM climo info variable strings:
-        self.__expand_references(self.__cam_climo_info, config_search_dict)
+        self.expand_references(self.__cam_climo_info)
 
         #Check if a CAM vs CAM baseline comparison is being performed:
         if not self.__basic_info['compare_obs']:
             #If so, then add CAM baseline climatology info to object:
-            self.__cam_bl_climo_info = read_config_obj(config,'diag_cam_baseline_climo')
+            self.__cam_bl_climo_info = self.read_config_var('diag_cam_baseline_climo')
 
             #Expand CAM baseline climo info variable strings:
-            self.__expand_references(self.__cam_bl_climo_info, config_search_dict)
+            self.expand_references(self.__cam_bl_climo_info)
 
         #Add averaging script names:
-        self.__time_averaging_scripts = read_config_obj(config, 'time_averaging_scripts')
+        self.__time_averaging_scripts = self.read_config_var('time_averaging_scripts')
 
         #Add regridding script names:
-        self.__regridding_scripts = read_config_obj(config, 'regridding_scripts')
+        self.__regridding_scripts = self.read_config_var('regridding_scripts')
 
         #Add analysis script names:
-        self.__analysis_scripts = read_config_obj(config, 'analysis_scripts')
+        self.__analysis_scripts = self.read_config_var('analysis_scripts')
 
         #Add plotting script names:
-        self.__plotting_scripts = read_config_obj(config, 'plotting_scripts')
+        self.__plotting_scripts = self.read_config_var('plotting_scripts')
 
         #Add CAM variable list:
-        self.__diag_var_list = read_config_obj(config, 'diag_var_list')
+        self.__diag_var_list = self.read_config_var('diag_var_list')
 
         #Add CAM observation type list (filename prefix for observation files):
-        self.__obs_type_list = read_config_obj(config, 'obs_type_list')
+        self.__obs_type_list = self.read_config_var('obs_type_list')
 
     # Create property needed to return "compare_obs" logical to user:
     @property
@@ -308,11 +251,10 @@ class CamDiag:
 
             if func_script_path not in sys.path:
                #Add script path to debug log if requested:
-               if self.__debug:
-                   if log_section:
-                       self.__debug_log.debug(f"{log_section}: Inserting to sys.path: {func_script_path}")
-                   else:
-                       self.__debug_log.debug(f"diag_scripts_caller: Inserting to sys.path: {func_script_path}")
+               if log_section:
+                   self.debug_log(f"{log_section}: Inserting to sys.path: {func_script_path}")
+               else:
+                   self.debug_log(f"diag_scripts_caller: Inserting to sys.path: {func_script_path}")
 
                #Add script to python path:
                sys.path.insert(0, func_script_path)
@@ -337,17 +279,16 @@ class CamDiag:
                     func_kwargs = opt['kwargs']
 
             #Add function calls debug log if requested:
-            if self.__debug:
-                if log_section:
-                    self.__debug_log.debug(\
+            if log_section:
+                self.debug_log(\
                     f"{log_section}: \n \t func_name = {func_name}\n \t func_args = {func_args}\n \t func_kwargs = {func_kwargs}")
-                else:
-                    self.__debug_log.debug(\
+            else:
+                self.debug_log(\
                     f"diag_scripts_caller: \n \t func_name = {func_name}\n \t func_args = {func_args}\n \t func_kwargs = {func_kwargs}")
 
 
             #Call function
-            self.__function_caller(avg_func_name, avg_func_args, func_kwargs=avg_func_kwargs, module_name=avg_func_name)
+            self.__function_caller(func_name, func_args, func_kwargs=func_kwargs, module_name=func_name)
 
     #########
 
@@ -374,231 +315,6 @@ class CamDiag:
 
         #Run function and return result:
         return func(*func_args, **func_kwargs)
-
-    #########
-
-    def __expand_references(self, config_dict, search_dict):
-
-        """
-        Replace keyword (${var} or ${dict.var}) entries
-        in the YAML (config) dictionary that reference
-        other YAML dictionary variables/keys with the
-        values of those variables.
-
-        Note:  Subsitutions currently only work for the
-               following variable types:
-
-               string
-               integer
-               float
-        """
-
-        #compile regular expression:
-        kword_regex = re.compile(r'\$\{[a-z_\.\d]+\}')
-
-        #copy YAML config dictionary:
-        config_dict_copy = config_dict
-
-        #Loop through dictionary:
-        for key, value in config_dict_copy.items():
-
-            #Skip boolean type:
-            #This must be done first because
-            #booleans are technically an integer
-            #sub-class.
-            if isinstance(value, bool):
-                continue
-
-            #Skipe any other non-accepted types:
-            if (not isinstance(value, str)) and \
-               (not isinstance(value, int)) and \
-               (not isinstance(value, float)):
-               continue
-
-            #determine variable type (if not a string):
-            if isinstance(value, int):
-                type_str = "int"
-            elif isinstance(value, float):
-                type_str = "float"
-            else:
-                type_str = None
-
-            #Skip the variable if it is not a string:
-            #if not isinstance(value, str):
-            #    continue
-
-            #expand any keywords to their full values:
-            new_value = self.__expand_yaml_var_ref(value, kword_regex,
-                                                 search_dict)
-
-            #Add full string back into dictionary:
-            if type_str == "int":
-                config_dict[key] = int(new_value)
-            elif type_str == "float":
-                config_dict[key] = float(new_value)
-            else:
-                #Note that the 'expand_yaml_var_ref' function
-                #always returns a string type, so leave as-is:
-                config_dict[key] = new_value
-
-    #########
-
-    def __expand_yaml_var_ref(self, var_val, kword_regex, search_dict):
-
-        """
-        Recursive function to replace all keywords with their
-        associated values from the provided dictionary.
-        """
-
-        #If variable value is not a string, then convert it:
-        if not isinstance(var_val, str):
-            var_val = str(var_val)
-
-        #Look for keyword using provided regular expression:
-        kword_match = kword_regex.search(var_val)
-
-        #Continue if at least one match is found:
-        if kword_match:
-
-            #Copy input variable value string,
-            #which is needed for generating
-            #proper error messages:
-            new_var_val = var_val
-
-            #Find all variable matches in variable string:
-            #kword_matches = kword_regex.finditer(var_val)
-
-            #Start while loop:
-            another_match = True
-
-            while another_match:
-
-                #Extract match string:
-                kword_match_str = kword_match.group(0)
-
-                #Remove special characters ("${" and "}"):
-                kword_match_str = kword_match_str[2:-1]
-
-                #Check if period (".") is in string,
-                #If so, then the keyword will be used directly,
-                #otherwise do the following:
-                #--------------------------
-                if kword_match_str.find(".") == -1:
-
-                    #Initalize match counter:
-                    match_count = 0
-
-                    #Loop through search dictionary keys:
-                    for key in search_dict.keys():
-
-                        #Attempt to find period string index:
-                        pidx = key.find(".")
-
-                        #If no period found, then compare directly with kword:
-                        if pidx == -1:
-                           if kword_match_str == key:
-                              #Add one to counter:
-                              match_count += 1
-
-                        else:
-                            #Compare kword to text on the right side of period:
-                            if kword_match_str == key[pidx+1:]:
-                                #Set match string to full key string:
-                                kword_match_str = key
-
-                                #Add one to counter:
-                                match_count += 1
-
-                    #If more than one match, then throw an error:
-                    if match_count > 1:
-                        ermsg = f"ERROR: More than one variable matches keyword in {var_val}"
-                        ermsg += "\nPlease use '${section.variable}' keyword method to specify"
-                        ermsg += " which variable you want to use."
-                        end_diag_script(ermsg)
-                #--------------------------
-
-                #Throw an error if keyword not in dictionary:
-                if kword_match_str not in search_dict.keys():
-                    ermsg = f"ERROR: Variable '{kword_match_str}'"
-                    ermsg += " not found in config (YAML) file."
-                    end_diag_script(ermsg)
-
-                #Extract keyword value from config dictionary:
-                kword_val = search_dict[kword_match_str]
-
-                #Expand keyword if found:
-                final_kword_val = self.__expand_yaml_var_ref(kword_val, kword_regex, search_dict)
-
-                #Substitute keyword with final kword_val:
-                new_var_val = new_var_val[:kword_match.start()] + final_kword_val + new_var_val[kword_match.end():]
-
-                #Search the string again for keyword values:
-                kword_match = kword_regex.search(new_var_val)
-
-                #End loop if no other matches found:
-                if not kword_match:
-                    another_match = False
-
-            #End while loop
-
-            #Pass back final value:
-            return new_var_val
-
-        else:
-            #Return the string un-modified:
-            return var_val
-
-    #########
-
-    def __create_search_dict(self, config_dict, sub_dict=None):
-
-        """
-        Recursive function that creates a non-hierarchical
-        dictionary for use in global key/value searches.
-        """
-
-        #Create empty dictionary:
-        config_search_dict = dict()
-
-        #Loop over all top-level config variables:
-        for key, value in config_dict.items():
-
-            #Check if value is a string, integer, or another dict:
-            if isinstance(value, str) or isinstance(value, int):
-
-                #Check if sub dictionary is present:
-                if sub_dict:
-                    #Create new key with sub dictionary prefix:
-                    key = sub_dict+"."+key
-
-                #Check if key already exists in search dict:
-                if key in config_search_dict.keys():
-
-                    ermsg = f"ERROR: Multiple versions of Variable {key}"
-                    ermsg += "exist at the same level in config (YAML) file."
-                    end_diag_script(ermsg)
-
-                #Add key/value to search dict:
-                config_search_dict[key] = str(value)
-
-            #Check if value is a dictionary instead:
-            elif isinstance(value, dict):
-                #Currently this routine only handles one level of
-                #nested dictionaries, so throw an error if one has
-                #gone beyond that:
-                if sub_dict:
-                    ermsg = "ERROR: CamDiag currently only allows for a single nested dict"
-                    ermsg += f"in the config (YAML) file.\n  Variable {value} is nested too far."
-
-                #Apply routine to sub dictionary:
-                sub_config_search_dict = self.__create_search_dict(value,
-                                                                 sub_dict = key)
-
-                #Append sub-dict search dictionary to top-level dictionary:
-                config_search_dict.update(sub_config_search_dict)
-
-        #Return search dictionary:
-        return config_search_dict
 
     #########
 
@@ -826,13 +542,13 @@ class CamDiag:
             #       do we need to still copy (symlink?) files into the regrid directory?
 
 
-       #Set default script arguments:
-       regrid_func_args = [case_name, input_climo_loc, output_loc, var_list, target_list, target_loc, overwrite_regrid]
+        #Set default script arguments:
+        regrid_func_args = [case_name, input_climo_loc, output_loc, var_list, target_list, target_loc, overwrite_regrid]
 
-       #Run the listed scripts:
-       self.__diag_scripts_caller("regridding", regrid_func_names, 
-                                  default_args = regrid_func_args,
-                                  log_section = "regrid_climo")
+        #Run the listed scripts:
+        self.__diag_scripts_caller("regridding", regrid_func_names,
+                                   default_args = regrid_func_args,
+                                   log_section = "regrid_climo")
 
     #########
 

--- a/lib/CamDiag.py
+++ b/lib/CamDiag.py
@@ -262,17 +262,17 @@ class CamDiag:
     #########
 
     def __diag_scripts_caller(self, scripts_dir: str, func_names: list,
-                              default_args: list = [], default_kwargs: dict = {}, 
+                              default_args: list = [], default_kwargs: dict = {},
                               log_section: str = ''):
-  
+
         """
         Parse a list of scripts as provided by the config file,
         and call them as functions while passing in the correct inputs.
 
         scripts_dir    : string, sub-directory under "scripts" where scripts are located
-        func_names     : list of function/scripts (either string or dictionary): 
+        func_names     : list of function/scripts (either string or dictionary):
         default_args   : optional list of default arguments for the scripts if none are specified by the config file
-        default_kwargs : optional list of default keyword arguments for the scripts if none are specified by the config file 
+        default_kwargs : optional list of default keyword arguments for the scripts if none are specified by the config file
         log_section    : optional variable that specifies where the log entries are coming from.
                          Note:  Is it better to just make a child log instead?
 

--- a/lib/unit_tests/test_adfbase.py
+++ b/lib/unit_tests/test_adfbase.py
@@ -14,11 +14,11 @@ import os.path
 import logging
 
 #Set relevant path variables:
-CURRDIR = os.path.abspath(os.path.dirname(__file__))
-ADF_LIB_DIR = os.path.join(CURRDIR, os.pardir)
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir)
 
 #Add ADF "lib" directory to python path:
-sys.path.append(ADF_LIB_DIR)
+sys.path.append(_ADF_LIB_DIR)
 
 #Import AdfBase class
 from AdfBase import AdfBase

--- a/lib/unit_tests/test_adfbase.py
+++ b/lib/unit_tests/test_adfbase.py
@@ -1,0 +1,177 @@
+"""
+Collection of python unit tests
+for the "AdfBase" class.
+"""
+
+#+++++++++++++++++++++++
+#Import required modules
+#+++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+import logging
+
+#Set relevant path variables:
+CURRDIR = os.path.abspath(os.path.dirname(__file__))
+ADF_LIB_DIR = os.path.join(CURRDIR, os.pardir)
+
+#Add ADF "lib" directory to python path:
+sys.path.append(ADF_LIB_DIR)
+
+#Import AdfBase class
+from AdfBase import AdfBase
+from AdfBase import AdfError
+
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#Main AdfBase testing routine, used when script is run directly
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+class AdfBaseTestRoutine(unittest.TestCase):
+
+    """
+    Runs all of the unit tests
+    for the AdfBase class.  Ideally
+    this set of tests will provide
+    complete code coverage for AdfBase.
+    """
+
+    #Set-up unit tests:
+    def tearDown(self):
+
+        """
+        Remove log files (if they exist).
+        """
+
+        #Remove log file if it exists:
+        if os.path.exists("ADF_debug.log"):
+            os.remove("ADF_debug.log")
+
+
+        #Close all log streams:
+        logging.shutdown()
+
+    def test_AdfBase_create(self):
+
+        """
+        Check that the Adfbase class can
+        be initialized properly.
+        """
+
+        #Create AdfBase object:
+        adf_test = AdfBase()
+
+        #Assert that new object is of the "AdfBase" class:
+        self.assertIsInstance(adf_test, AdfBase)
+
+    def test_AdfBase_debug_create(self):
+
+        """
+        Check that the Adfbase class can
+        be initialized properly when the
+        debug flag is set, and that a
+        debug log file is created.
+        """
+
+        #Create AdfBase object with debug setting:
+        adf_test = AdfBase(debug=True)
+
+        #Assert that new object is of the "AdfBase" class:
+        self.assertIsInstance(adf_test, AdfBase)
+
+        #Assert that "ADF_debug.log" file exists in local directory:
+        self.assertTrue(os.path.exists("ADF_debug.log"))
+
+    def test_AdfBase_bad_debug(self):
+
+        """
+        Check that the Adfbase class
+        throws the proper error if a bad
+        value is passed-in via the "debug" variable.
+        """
+
+        #Set error message:
+        ermsg = "'debug' must be a boolean type (True or False)"
+
+        #Expect a Type error:
+        with self.assertRaises(TypeError) as typerr:
+
+            #Create AdfBase object with bad debug setting:
+            adf_test = AdfBase(debug=5)
+
+        #Check that error message matches what's expected:
+        self.assertEqual(ermsg, str(typerr.exception))
+
+
+    def test_AdfBase_debug_nothing(self):
+
+        """
+        Check that using the "debug_log" method
+        without debugging enabled does nothing.
+        """
+
+        #Create AdfBase object with no debug setting:
+        adf_test = AdfBase()
+
+        #Call "debug_log" method:
+        adf_test.debug_log("test")
+
+        #Check that no log file exists:
+        self.assertFalse(os.path.exists("ADF_debug.log"))
+
+    def test_AdfBase_debug_write(self):
+
+        """
+        Check that using the "debug_log" method
+        with debugging enabled properly writes
+        a message to the debug log file.
+        """
+
+        #Create AdfBase object with debug setting:
+        adf_test = AdfBase(debug=True)
+
+        #Call "debug_log" method:
+        adf_test.debug_log("test")
+
+        #Check that debug log exists:
+        self.assertTrue(os.path.exists("ADF_debug.log"))
+
+        #If debug log exists, then open file:
+        if os.path.exists("ADF_debug.log"):
+
+            #Open log file:
+            with open("ADF_debug.log") as logfil:
+
+                #Extract file contents:
+                log_text = logfil.read()
+
+                #Check that log text matches what was written:
+                self.assertEqual("DEBUG:ADF:test\n",log_text)
+
+    def test_AdfBase_script_end_fail(self):
+
+        """
+        Check that using "end_diag_fail" raises
+        the correct exception and error message
+        """
+
+        #Create AdfBase object:
+        adf_test = AdfBase()
+
+        #Expect a Type error:
+        with self.assertRaises(AdfError) as adferr:
+
+            #Call "end_diag_fail" method:
+            adf_test.end_diag_fail("test")
+
+        #Check that error message matches what's expected:
+        self.assertEqual("test", str(adferr.exception))
+
+#++++++++++++++++++++++++++++++++++++++++++++++++
+#Run unit tests if this script is called directly
+#++++++++++++++++++++++++++++++++++++++++++++++++
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/lib/unit_tests/test_adfconfig.py
+++ b/lib/unit_tests/test_adfconfig.py
@@ -1,0 +1,317 @@
+"""
+Collection of python unit tests
+for the "AdfConfig" class.
+"""
+
+#+++++++++++++++++++++++
+#Import required modules
+#+++++++++++++++++++++++
+
+import unittest
+import sys
+import os
+import os.path
+
+#Set relevant path variables:
+_CURRDIR = os.path.abspath(os.path.dirname(__file__))
+_ADF_LIB_DIR = os.path.join(_CURRDIR, os.pardir)
+_TEST_FILES_DIR = os.path.join(_CURRDIR, "test_files")
+
+#Add ADF "lib" directory to python path:
+sys.path.append(_ADF_LIB_DIR)
+
+#Import AdfConfig class and AdfError
+from AdfConfig import AdfConfig
+from AdfBase import AdfError
+
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+#Main AdfBase testing routine, used when script is run directly
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+class AdfConfigTestRoutine(unittest.TestCase):
+
+    """
+    Runs all of the unit tests
+    for the AdfConfig class.  Ideally
+    this set of tests will provide
+    complete code coverage for AdfConfig.
+    """
+    def test_AdfConfig_create(self):
+
+        """
+        Check that the AdfConfig class can
+        be initialized properly.
+        """
+
+        #Use example config file:
+        baseline_example_file = os.path.join(_ADF_LIB_DIR, os.pardir, "config_cam_baseline_example.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(baseline_example_file)
+
+        #Assert that new object is of the "AdfConfig" class:
+        self.assertIsInstance(adf_test, AdfConfig)
+
+        #Also check that "read_config_var" works as expected:
+        basic_diag_dict = adf_test.read_config_var("diag_basic_info")
+
+        cam_case_name_val = adf_test.read_config_var("cam_case_name", conf_dict=basic_diag_dict)
+
+        self.assertEqual(cam_case_name_val, "new_best.came-run")
+
+    #####
+
+    def test_AdfConfig_missing_file(self):
+
+        """
+        Check that AdfConfig throws the
+        proper error when no config file
+        is found.
+        """
+
+        #Set error message:
+        ermsg = "File 'not_real.yaml' not found. Please provide full path."
+
+        #Expect a FileNotFound error:
+        with self.assertRaises(FileNotFoundError) as err:
+
+            #Try and create AdfConfig object with non-existent file:
+            adf_test = AdfConfig("not_real.yaml")
+
+        #Check that error message matches what's expected:
+        self.assertEqual(ermsg, str(err.exception))
+
+    #####
+
+    def test_AdfConfig_double_nested_config_var(self):
+
+        """
+        Check that AdfConfig throws the
+        proper error when there is a
+        doubly-nested variable present
+        in the config (YAML) file.
+        """
+
+        #Use double-nested var config file:
+        unset_example_file = os.path.join(_TEST_FILES_DIR, "config_cam_double_nested.yaml")
+
+        #Set error message:
+        ermsg = "ADF currently only allows for a single nested dict"
+        ermsg += " in the config (YAML) file.\n  Variable '{'double_nested_var': 'bad_val'}' is nested too far."
+
+        #Expect an ADF error:
+        with self.assertRaises(AdfError) as err:
+
+            #Try and create AdfConfig object with doubly-nested config variable:
+            adf_test = AdfConfig(unset_example_file)
+
+        #Check that error message matches what's expected:
+        self.assertEqual(ermsg, str(err.exception))
+
+    #####
+
+    def test_AdfConfig_read_config_bad_conf_dict(self):
+
+        """
+        Check that the "read_config_var"
+        method throws the correct error
+        when a non-dictionary is passed
+        to "conf_dict".
+        """
+
+        #Use example config file:
+        baseline_example_file = os.path.join(_ADF_LIB_DIR, os.pardir, "config_cam_baseline_example.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(baseline_example_file)
+
+        #Set error message:
+        ermsg = "Supplied 'conf_dict' variable should be a dictionary, not type '<class 'str'>'"
+
+        #Expect a Type error:
+        with self.assertRaises(TypeError) as err:
+
+            #Try to read variable with bad "conf_dict" type:
+            _ = adf_test.read_config_var("diag_basic_info", conf_dict="hello")
+
+        #Check that error message matches what's expected:
+        self.assertEqual(ermsg, str(err.exception))
+
+    #####
+
+    def test_AdfConfig_read_config_missing_var(self):
+
+        """
+        Check that the "read_config_var"
+        method throws the correct error
+        when a variable is requested that
+        doesn't exist in the config dictionary.
+        """
+
+        #Use example config file:
+        baseline_example_file = os.path.join(_ADF_LIB_DIR, os.pardir, "config_cam_baseline_example.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(baseline_example_file)
+
+        #Set error message:
+        #Note that for some reason a KeyError adds exra quotes,
+        #hence the extra string quotes here
+        ermsg = '''"Variable 'hello' not found in config file.  Please see 'config_cam_baseline_example.yaml'."'''
+
+        #Expect a Key error:
+        with self.assertRaises(KeyError) as err:
+
+            #Try to read non-existing variable:
+            _ = adf_test.read_config_var("hello")
+
+        #Check that error message matches what's expected:
+        self.assertEqual(ermsg, str(err.exception))
+
+    #####
+
+    def test_AdfConfig_read_config_unset_var(self):
+
+        """
+        Check that the "read_config_var"
+        method throws the correct error
+        when a variable is requested that
+        exists but hasn't been set to a value
+        """
+
+        #Use unset var config file:
+        unset_example_file = os.path.join(_TEST_FILES_DIR, "config_cam_unset_var.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(unset_example_file)
+
+        #Set error message:
+        ermsg = "Variable 'bad_var' has not been set to a value. Please see 'config_cam_baseline_example.yaml'."
+
+        #Expect a Value error:
+        with self.assertRaises(ValueError) as err:
+
+            #Try to read non-existing variable:
+            _ = adf_test.read_config_var("bad_var")
+
+        #Check that error message matches what's expected:
+        self.assertEqual(ermsg, str(err.exception))
+
+    #####
+
+    def test_AdfConfig_expand_references(self):
+
+        """
+        Check that the AdfConfig class can
+        properly expand variables using keywords
+        """
+
+        #Use example config file:
+        keyword_example_file = os.path.join(_TEST_FILES_DIR, "config_cam_keywords.yaml")
+
+        #Create AdfConfig object:
+        adf_test = AdfConfig(keyword_example_file)
+
+        #Check that variables match pre-expansion:
+        test_dict = adf_test.read_config_var("good_dict")
+        test_dict_two = adf_test.read_config_var("good_dict_two")
+
+        test_var = adf_test.read_config_var("good_var", conf_dict=test_dict)
+        test_var_two = adf_test.read_config_var("good_var", conf_dict=test_dict_two)
+
+        self.assertEqual(test_var, "It says ${test_var} and ${another_var}.")
+        self.assertEqual(test_var_two, "${good_dict.good_var}")
+
+        #Now expand variable references and check results:
+        adf_test.expand_references(test_dict)
+        adf_test.expand_references(test_dict_two)
+
+        test_var_expanded = adf_test.read_config_var("good_var", conf_dict=test_dict)
+        test_var_two_expanded = adf_test.read_config_var("good_var", conf_dict=test_dict_two)
+
+        self.assertEqual(test_var_expanded, "It says yay! and 5.")
+        self.assertEqual(test_var_two_expanded, "It says yay! and 5.")
+
+    #####
+
+    def test_AdfConfig_expand_references_non_specific_var(self):
+
+       """
+       Check that expand_references throws
+       the correct error when a variable
+       is used in a keyword that is defined
+       in multiple different locations
+       """
+
+       #Use example config file:
+       keyword_example_file = os.path.join(_TEST_FILES_DIR, "config_cam_keywords.yaml")
+
+       #Create AdfConfig object:
+       adf_test = AdfConfig(keyword_example_file)
+
+       #Check that variable matches pre-expansion:
+       test_dict = adf_test.read_config_var("bad_dict")
+
+       test_var = adf_test.read_config_var("bad_var", conf_dict=test_dict)
+
+       self.assertEqual(test_var, "${good_var}")
+
+       #Set error message:
+       ermsg = "More than one variable matches keyword '${good_var}'"
+       ermsg += "\nPlease use '${section.variable}' keyword method to specify"
+       ermsg += " which variable you want to use."
+
+       #Expect an ADF error:
+       with self.assertRaises(AdfError) as err:
+
+           #Now check for failure when variable reference is expanded:
+           adf_test.expand_references(test_dict)
+
+       #Check that error message matches what's expected:
+       self.assertEqual(ermsg, str(err.exception))
+
+    #####
+
+    def test_AdfConfig_expand_references_non_existent_var(self):
+
+       """
+       Check that expand_references throws
+       the correct error when a variable
+       is used in a keyword that doesn't
+       actually exist in the config file.
+       """
+
+       #Use example config file:
+       keyword_example_file = os.path.join(_TEST_FILES_DIR, "config_cam_keywords.yaml")
+
+       #Create AdfConfig object:
+       adf_test = AdfConfig(keyword_example_file)
+
+       #Check that variable matches pre-expansion:
+       test_dict = adf_test.read_config_var("bad_dict_two")
+
+       test_var = adf_test.read_config_var("bad_var_two", conf_dict=test_dict)
+
+       self.assertEqual(test_var, "${no_var}")
+
+       #Set error message:
+       ermsg = f"ERROR: Variable 'no_var'"
+       ermsg += " not found in config (YAML) file."
+
+       #Expect an ADF error:
+       with self.assertRaises(AdfError) as err:
+
+           #Now check for failure when variable reference is expanded:
+           adf_test.expand_references(test_dict)
+
+       #Check that error message matches what's expected:
+       self.assertEqual(ermsg, str(err.exception))
+
+
+#++++++++++++++++++++++++++++++++++++++++++++++++
+#Run unit tests if this script is called directly
+#++++++++++++++++++++++++++++++++++++++++++++++++
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/lib/unit_tests/test_files/config_cam_double_nested.yaml
+++ b/lib/unit_tests/test_files/config_cam_double_nested.yaml
@@ -1,0 +1,58 @@
+#==============================
+#config_cam_baseline.yaml
+
+#This is the main CAM diagnostics config file
+#for doing comparisons of a CAM run against
+#another CAM run, or a CAM baseline simulation.
+
+#Currently, if one is on NCAR's Casper
+#machine, then only the CAM model data
+#paths, case names, and model year spans
+#are needed.  Running this diagnostics on
+#a different machine, or with a different model,
+#may require additional modifications.
+#
+#Config file Keywords:
+#--------------------
+#
+#1.  Using ${xxx} will substitute that text with the
+#    variable referenced by xxx. For example:
+#
+#    cam_case_name: cool_run
+#    cam_climo_loc: /some/where/${cam_case_name}
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/cool_run
+#
+#2.  Using ${<top_level_section>.xxx} will do the same as
+#    keyword 1 above, but specifies which sub-section the
+#    variable is coming from, which is necessary for variables
+#    that are repeated in different subsections.  For example:
+#
+#    diag_basic_info:
+#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
+#
+#    diag_cam_climo:
+#      start_year: 1850
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/1850
+#
+#Please note that for both 1 and 2 the keywords must be lowercase.
+#This is because future developments will hopefully use other keywords
+#that are uppercase.
+#--------------------
+#
+##==============================
+
+test_var: yay!
+
+another_var: 5
+
+config_info:
+
+  nested_var:
+
+    double_nested_var: bad_val
+
+#END OF FILE

--- a/lib/unit_tests/test_files/config_cam_keywords.yaml
+++ b/lib/unit_tests/test_files/config_cam_keywords.yaml
@@ -1,0 +1,68 @@
+#==============================
+#config_cam_baseline.yaml
+
+#This is the main CAM diagnostics config file
+#for doing comparisons of a CAM run against
+#another CAM run, or a CAM baseline simulation.
+
+#Currently, if one is on NCAR's Casper
+#machine, then only the CAM model data
+#paths, case names, and model year spans
+#are needed.  Running this diagnostics on
+#a different machine, or with a different model,
+#may require additional modifications.
+#
+#Config file Keywords:
+#--------------------
+#
+#1.  Using ${xxx} will substitute that text with the
+#    variable referenced by xxx. For example:
+#
+#    cam_case_name: cool_run
+#    cam_climo_loc: /some/where/${cam_case_name}
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/cool_run
+#
+#2.  Using ${<top_level_section>.xxx} will do the same as
+#    keyword 1 above, but specifies which sub-section the
+#    variable is coming from, which is necessary for variables
+#    that are repeated in different subsections.  For example:
+#
+#    diag_basic_info:
+#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
+#
+#    diag_cam_climo:
+#      start_year: 1850
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/1850
+#
+#Please note that for both 1 and 2 the keywords must be lowercase.
+#This is because future developments will hopefully use other keywords
+#that are uppercase.
+#--------------------
+#
+##==============================
+
+test_var: yay!
+
+another_var: 5
+
+good_dict:
+
+  good_var: It says ${test_var} and ${another_var}.
+
+good_dict_two:
+
+  good_var: ${good_dict.good_var}
+
+bad_dict:
+
+  bad_var: ${good_var}
+
+bad_dict_two:
+
+  bad_var_two: ${no_var}
+
+#END OF FILE

--- a/lib/unit_tests/test_files/config_cam_unset_var.yaml
+++ b/lib/unit_tests/test_files/config_cam_unset_var.yaml
@@ -1,0 +1,54 @@
+#==============================
+#config_cam_baseline.yaml
+
+#This is the main CAM diagnostics config file
+#for doing comparisons of a CAM run against
+#another CAM run, or a CAM baseline simulation.
+
+#Currently, if one is on NCAR's Casper
+#machine, then only the CAM model data
+#paths, case names, and model year spans
+#are needed.  Running this diagnostics on
+#a different machine, or with a different model,
+#may require additional modifications.
+#
+#Config file Keywords:
+#--------------------
+#
+#1.  Using ${xxx} will substitute that text with the
+#    variable referenced by xxx. For example:
+#
+#    cam_case_name: cool_run
+#    cam_climo_loc: /some/where/${cam_case_name}
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/cool_run
+#
+#2.  Using ${<top_level_section>.xxx} will do the same as
+#    keyword 1 above, but specifies which sub-section the
+#    variable is coming from, which is necessary for variables
+#    that are repeated in different subsections.  For example:
+#
+#    diag_basic_info:
+#      cam_climo_loc:  /some/where/${diag_cam_climo.start_year}
+#
+#    diag_cam_climo:
+#      start_year: 1850
+#
+#    will set "cam_climo_loc" in the diagnostics package to:
+#    /some/where/1850
+#
+#Please note that for both 1 and 2 the keywords must be lowercase.
+#This is because future developments will hopefully use other keywords
+#that are uppercase.
+#--------------------
+#
+##==============================
+
+test_var:  yay!
+
+another_var: 5
+
+bad_var:
+
+#END OF FILE

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
-script: run_diag
+script: run_adf_diag
 
 goal:  To allow a user to easily run the CAM diagnostics package from
        the command line.
@@ -31,7 +31,7 @@ import sys
 import argparse
 
 #+++++++++++++++++++++++++++++
-#Import CAM diagnostics module
+#Import ADF diagnostics module
 #+++++++++++++++++++++++++++++
 
 #Determine local directory path:
@@ -48,11 +48,11 @@ else:
     #If not, then raise error:
     raise FileNotFoundError("'./lib' directory not found. Has 'run_diag' been moved?")
 
-#Import CAM diagnostics object:
-from CamDiag import CamDiag
+#Import ADF diagnostics object:
+from AdfDiag import AdfDiag
 
-#Import CAM diagnostics exiting script:
-from CamDiag import end_diag_script
+#Import ADF diagnostics error classt:
+from AdfBase import AdfError
 
 #################
 #Helper functions
@@ -109,19 +109,19 @@ def parse_arguments():
 if __name__ == "__main__":
 
     #+++++++++++++++++++++
-    #Begin CAM diag script
+    #Begin ADF diag script
     #+++++++++++++++++++++
-    print('CAM diagnostics is starting...')
+    print('ADF diagnostics is starting...')
 
     #+++++++++++++++++++++++++++++++++++++++++++
-    #Check that python is version 3.4 or greater
+    #Check that python is version 3.6 or greater
     #+++++++++++++++++++++++++++++++++++++++++++
 
     if sys.version_info[0] < 3:
-        end_diag_script("Script only works with Python 3. Please switch python versions.")
+        raise AdfError("Script only works with Python 3. Please switch python versions.")
 
     if sys.version_info[1] < 6:
-        end_diag_script("Script only works with Python version 3.6 or greater.  Please update python.")
+        raise AdfError("Script only works with Python version 3.6 or greater.  Please update python.")
 
     #++++++++++++++++++++++++++++
     #Parse command-line arguments
@@ -139,31 +139,31 @@ if __name__ == "__main__":
     config_debug = args.debug
 
     #+++++++++++++++++++++++++++++++++
-    #Call main CAM diagnostics methods
+    #Call main ADF diagnostics methods
     #+++++++++++++++++++++++++++++++++
 
     #Initalize CAM diagnostics object:
-    diag = CamDiag(config_yaml, debug=config_debug)
+    diag = AdfDiag(config_yaml, debug=config_debug)
 
-    #Create CAM time series:
+    #Create model time series:
     diag.create_time_series()
 
-    #Create CAM baseline time series (if needed):
+    #Create model baseline time series (if needed):
     if not diag.compare_obs:
         diag.create_time_series(baseline=True)
 
-    #Create CAM climatology (climo) files.
+    #Create model climatology (climo) files.
     #This call uses the "time_averaging_script" specified
     #in the config file:
     diag.create_climo()
 
-    #Create CAM baseline climatology files (if needed).
+    #Create model baseline climatology files (if needed).
     #This call uses the "time_averaging_script" specified
     #in the config file:
     if not diag.compare_obs:
         diag.create_climo(baseline=True)
 
-    #Regrid CAM climatology files to match either
+    #Regrid model climatology files to match either
     #observations or CAM baseline climatologies:
     diag.regrid_climo()
 
@@ -184,5 +184,5 @@ if __name__ == "__main__":
     #+++++++++++++++
     #End diag script
     #+++++++++++++++
-    print('CAM diagnostics has completed successfully.')
+    print('ADF diagnostics has completed successfully.')
     sys.exit(0)

--- a/scripts/analysis/amwg_table.py
+++ b/scripts/analysis/amwg_table.py
@@ -27,7 +27,7 @@ def amwg_table(case_name, input_ts_loc, output_loc, var_list, write_html):
     import numpy as np
     import xarray as xr
     from pathlib import Path
-    from CamDiag import end_diag_script #Diagnostics routine
+    from AdfBase import AdfError
     import warnings  # use to warn user about missing files.
 
     #Import "special" modules:
@@ -97,7 +97,7 @@ def amwg_table(case_name, input_ts_loc, output_loc, var_list, write_html):
     #Check that time series input directory actually exists:
     if not input_location.is_dir():
         errmsg = "Time series directory '{}' not found.  Script is exiting.".format(input_ts_loc)
-        end_diag_script(errmsg)
+        raise AdfError(errmsg)
     # print(f"DEBUG: location of files is {str(input_location)}")
     # TODO: add location of files to debug log
     #Check if analysis directory exists, and if not, then create it:
@@ -145,7 +145,7 @@ def amwg_table(case_name, input_ts_loc, output_loc, var_list, write_html):
         if len(ts_files) != 1:
             errmsg =  "Currently the AMWG table script can only handle one time series file per variable."
             errmsg += " Multiple files were found for the variable '{}'".format(var)
-            end_diag_script(errmsg)
+            raise AdfError(errmsg)
 
         #Load model data from file:
         data = _load_data(ts_files[0], var)

--- a/scripts/averaging/averaging_example.py
+++ b/scripts/averaging/averaging_example.py
@@ -33,7 +33,7 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, clobber=Fal
     #Import necessary modules:
     import xarray as xr
     from pathlib import Path
-    from CamDiag import end_diag_script
+    from AdfBase import AdfError
 
     #Notify user that script has started:
     print("  Calculating CAM climatologies...")
@@ -45,7 +45,7 @@ def averaging_example(case_name, input_ts_loc, output_loc, var_list, clobber=Fal
     #Check that time series input directory actually exists:
     if not input_location.is_dir():
         errmsg = "Time series directory '{}' not found.  Script is exiting.".format(input_ts_loc)
-        end_diag_script(errmsg)
+        raise AdfError(errmsg)
 
     #Check if climo directory exists, and if not, then create it:
     if not output_location.is_dir():


### PR DESCRIPTION
Major PR which pulls out much of the code present in the old `CamDiag` class and instead has the class inherit these methods from sub-classes (`AdfBase` and `AdfConfig`).  Also tried to replace references to "CAM" with "ADF", and also added unit tests and an associated Github Actions workflow to automatically run these tests whenever a PR is opened or updated.

Fixes #33 
Fixes #35 

Addresses #4 