### PR TITLE
Move website directory to avoid accidental overwrites

### DIFF
--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -28,8 +28,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip  # Install latest version of PIP
         pip install pyyaml
-    # Run python unit tests:
-    - name: python unit tests
+    # Run python unit tests related to ADF library:
+    - name: ADF lib unit tests
       run: |
         #AdfBase unit tests:
         python lib/unit_tests/test_adfbase.py

--- a/.github/workflows/pr_open_sync_workflow.yml
+++ b/.github/workflows/pr_open_sync_workflow.yml
@@ -23,6 +23,11 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    # Install needed python packages:
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip  # Install latest version of PIP
+        pip install pyyaml
     # Run python unit tests:
     - name: python unit tests
       run: |

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -56,7 +56,9 @@ diag_basic_info:
 
   #Generate HTML website:
   #Note:  The website files themselves will be located in the path
-  #specified by "cam_diag_plot_loc", under the "website" sub-directory
+  #specified by "cam_diag_plot_loc", under the "<diag_run>/website" subdirectory,
+  #where "<diag_run>" is the subdirectory created for this particular diagnostics run
+  #(usually "case_vs_obs_XXX" or "case_vs_baseline_XXX").
   create_html: true
 
   #Location of observational climatologies (only matters if "compare_obs" is true):
@@ -100,13 +102,13 @@ diag_cam_climo:
   #Location of CAM history (h0) files:
   cam_hist_loc: /location/where/you/stored/model/outputs
 
-  #model year when climatology should start:
-  #Note:  Leaving this entry blank will make diagnostics
+  #model year when time series files should start:
+  #Note:  Leaving this entry blank will make time series
   #       start at earliest available year.
   start_year: 1850
 
-  #model year when diagnostics should end:
-  #Note:  Leaving this entry blank will make diagnostics
+  #model year when time series files should end:
+  #Note:  Leaving this entry blank will make time series
   #       end at latest available year.
   end_year: 2100
 
@@ -143,12 +145,12 @@ diag_cam_baseline_climo:
   #Location of CAM history (h0) files:
   cam_hist_loc: /location/of/second/cam/run/output/or/baseline/data
 
-  #model year when climatology should start:
+  #model year when time series files should start:
   #Note:  Leaving this entry blank will make diagnostics
   #       start at earliest available year.
   start_year: 1850
 
-  #model year when diagnostics should end:
+  #model year when time series files should end:
   #Note:  Leaving this entry blank will make diagnostics
   #       end at latest available year.
   end_year: 2100

--- a/config_cam_baseline_example.yaml
+++ b/config_cam_baseline_example.yaml
@@ -146,12 +146,12 @@ diag_cam_baseline_climo:
   cam_hist_loc: /location/of/second/cam/run/output/or/baseline/data
 
   #model year when time series files should start:
-  #Note:  Leaving this entry blank will make diagnostics
+  #Note:  Leaving this entry blank will make time series
   #       start at earliest available year.
   start_year: 1850
 
   #model year when time series files should end:
-  #Note:  Leaving this entry blank will make diagnostics
+  #Note:  Leaving this entry blank will make time series
   #       end at latest available year.
   end_year: 2100
 

--- a/run_adf_diag
+++ b/run_adf_diag
@@ -179,7 +179,7 @@ if __name__ == "__main__":
 
     #Create website:
     if diag.create_html:
-        diag.create_webpage()
+        diag.create_website()
 
     #+++++++++++++++
     #End diag script

--- a/scripts/plotting/global_latlon_map.py
+++ b/scripts/plotting/global_latlon_map.py
@@ -52,8 +52,7 @@ def global_latlon_map(case_name, model_rgrid_loc, data_name, data_loc,
     #------------------------------------
     dclimo_loc    = Path(data_loc)
     mclimo_rg_loc = Path(model_rgrid_loc)
-    plot_root     = Path(plot_location)
-    plot_loc      = plot_root / '{}_vs_{}'.format(case_name, data_name)
+    plot_loc      = Path(plot_location)
     #-----------------------------------
 
     #Set seasonal ranges:

--- a/scripts/plotting/plot_example.py
+++ b/scripts/plotting/plot_example.py
@@ -46,8 +46,7 @@ def plot_example(case_name, model_rgrid_loc, data_name, data_loc,
     #------------------------------------
     dclimo_loc    = Path(data_loc)
     mclimo_rg_loc = Path(model_rgrid_loc)
-    plot_root     = Path(plot_location)
-    plot_loc      = plot_root / '{}_vs_{}'.format(case_name, data_name)
+    plot_loc      = Path(plot_location)
     #-----------------------------------
 
     #Set seasonal ranges:

--- a/scripts/plotting/zonal_mean.py
+++ b/scripts/plotting/zonal_mean.py
@@ -50,8 +50,7 @@ def zonal_mean(case_name, model_rgrid_loc, data_name, data_loc,
     #------------------------------------
     dclimo_loc    = Path(data_loc)
     mclimo_rg_loc = Path(model_rgrid_loc)
-    plot_root     = Path(plot_location)
-    plot_loc      = plot_root / '{}_vs_{}'.format(case_name, data_name)
+    plot_loc      = Path(plot_location)
     #-----------------------------------
 
     #Set seasonal ranges:


### PR DESCRIPTION
This PR moves the `website` directory so that it is underneath the generated plots subdirectory (i.e. the `X_vs_Y` directory).  This subdirectory name now also contains the `start_year` and `end_year` of the non-baseline case, if provided, which can also assist in avoiding accidental overwrites.

To fully fix this issue, the start year and end year should be determined from the provided model data and added to the subdirectory name even if it hasn't been provided by the user in the config file.  That would help avoid mistaken overwrites in almost all situations.

addresses #39 
